### PR TITLE
Addition of inertial data for tx2_60l_macro.xacro / Ajout des données inertielles dans le fichier tx2_60l_macro.xacro

### DIFF
--- a/staubli_tx2_60_support/urdf/tx2_60l_macro.xacro
+++ b/staubli_tx2_60_support/urdf/tx2_60l_macro.xacro
@@ -18,6 +18,11 @@
           <mesh filename="package://staubli_tx2_60_support/meshes/tx2_60/collision/base_link.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.011857868431835556 -0.0005702896207627726 0.08747927245473501"/>
+        <mass value="10.6823103176789"/>
+        <inertia ixx="1.85344280021838E-05" ixy="-2.31141857694516E-07" ixz="-1.16581491551067E-06" iyy="2.55287335659137E-05" iyz="-3.64155850618543E-08" izz="2.21061777564787E-05"/>
+      </inertial>
     </link>
     <link name="${prefix}link_1">
       <visual>
@@ -33,6 +38,11 @@
           <mesh filename="package://staubli_tx2_60_support/meshes/tx2_60/collision/link_1.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.0002285353447226517 0.023189809238016817 -0.052488550111703516"/>
+        <mass value="14.2302371086183"/>
+        <inertia ixx="4.34004017739053E-05" ixy="-2.58214281446263E-08" ixz="-1.27951325597467E-07" iyy="3.69239685383464E-05" iyz="-7.31962719398484E-06" izz="2.70097973306662E-05"/>
+      </inertial>
     </link>
     <link name="${prefix}link_2">
       <visual>
@@ -48,6 +58,11 @@
           <mesh filename="package://staubli_tx2_60_support/meshes/tx2_60l/collision/link_2.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="0.0024412154327003465 0.1737660599134141 0.17061505310650313"/>
+        <mass value="14.2302371086183"/>
+        <inertia ixx="0.00010001687616627" ixy="2.08481020061818E-08" ixz="-4.21098449543997E-07" iyy="0.000104610940202223" iyz="2.92918661594567E-06" izz="8.60478266715016E-06"/>
+      </inertial>
     </link>
     <link name="${prefix}link_3">
       <visual>
@@ -63,6 +78,11 @@
           <mesh filename="package://staubli_tx2_60_support/meshes/tx2_60/collision/link_3.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.0038947770048615967 0.019187552998538967 -0.00793704005168346"/>
+        <mass value="9.41493563267085"/>
+        <inertia ixx="2.15775757267938E-05" ixy="-5.00434008520134E-07" ixz="-1.05431360916619E-07" iyy="1.63103141598017E-05" iyz="4.48088393277304E-07" izz="1.42191172320919E-05"/>
+      </inertial>
     </link>
     <link name="${prefix}link_4">
       <visual>
@@ -78,6 +98,11 @@
           <mesh filename="package://staubli_tx2_60_support/meshes/tx2_60l/collision/link_4.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.001196678757916788 -4.237083260958622e-06 0.287700023267439"/>
+        <mass value="7.37352895643548"/>
+        <inertia ixx="3.0890080746861E-05" ixy="-7.27397851829236E-11" ixz="7.09464652067665E-07" iyy="2.97701772752432E-05" iyz="-7.4095523114347E-10" izz="5.0160916630499E-06"/>
+      </inertial>
     </link>
     <link name="${prefix}link_5">
       <visual>
@@ -93,6 +118,11 @@
           <mesh filename="package://staubli_tx60_support/meshes/tx60/collision/link_5.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-3.504783915265423e-07 -8.22010607485609e-07 0.012689357805802624"/>
+        <mass value="0.319382165759376"/>
+        <inertia ixx="9.11236324080789E-08" ixy="1.13174263886652E-12" ixz="3.50191180593781E-12" iyy="9.63965142949116E-08" iyz="1.12088885236913E-12" izz="4.60261130158078E-08"/>
+      </inertial>
     </link>
     <link name="${prefix}link_6">
       <visual>
@@ -108,6 +138,11 @@
           <mesh filename="package://staubli_tx60_support/meshes/tx60/collision/link_6.stl"/>
         </geometry>
       </collision>
+      <inertial>
+        <origin rpy="0 0 0" xyz="-0.00021927141309218117 5.114205186745118e-08 -0.005966877359840437"/>
+        <mass value="0.0161227863265474"/>
+        <inertia ixx="6.95833551675001E-10" ixy="-6.72147918060976E-17" ixz="3.88472127913386E-12" iyy="6.74924502044574E-10" iyz="-1.35178181018499E-15" izz="1.11226129645795E-09"/>
+      </inertial>
     </link>
 
     <!-- joints: main serial chain -->


### PR DESCRIPTION
Addition of inertial data for tx2_60l_macro.xacro.
Thesse data were estimated via freeCAD by considering that robot's meshes were full Aluminium pieces. A correction was then applied to stick to the robot's datasheets mass.

Ajout des données inertielles dans le fichier tx2_60l_macro.xacro.
Ces données sont une estimations obtenues via freeCAD en considérant que les modèles meshes du robot étaient des pièces pleines en Aluminium. Une correction a ensuite été appliquée pour coller à la masse de la datasheet du robot.